### PR TITLE
Add profiling flags zstor client

### DIFF
--- a/profile/client_profile.go
+++ b/profile/client_profile.go
@@ -19,7 +19,7 @@ func main() {
 		defer profile.Start(profile.ProfilePath(*profileOutDir), profile.CPUProfile).Stop()
 	case "mem":
 		defer profile.Start(profile.ProfilePath(*profileOutDir), profile.MemProfile).Stop()
-	case "mutex":
+	case "trace":
 		defer profile.Start(profile.ProfilePath(*profileOutDir), profile.TraceProfile).Stop()
 	case "block":
 		defer profile.Start(profile.ProfilePath(*profileOutDir), profile.BlockProfile).Stop()

--- a/profile/client_profile.go
+++ b/profile/client_profile.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/pkg/profile"
+)
+
+var (
+	profileOutDir = flag.String("profileOutDir", "", "")
+	profileMode   = flag.String("profile.mode", "", "enable profiling mode, one of [cpu, mem, trace, block]")
+)
+
+func main() {
+	flag.Parse()
+
+	switch *profileMode {
+	case "cpu":
+		defer profile.Start(profile.ProfilePath(*profileOutDir), profile.CPUProfile).Stop()
+	case "mem":
+		defer profile.Start(profile.ProfilePath(*profileOutDir), profile.MemProfile).Stop()
+	case "mutex":
+		defer profile.Start(profile.ProfilePath(*profileOutDir), profile.TraceProfile).Stop()
+	case "block":
+		defer profile.Start(profile.ProfilePath(*profileOutDir), profile.BlockProfile).Stop()
+	default:
+		return
+	}
+
+	// code for client
+}


### PR DESCRIPTION
closes #379

This script will trigger a single profiling mode. In order to trigger all available profiling modes, the script should be called several times. It seems that package `profile` does not support profiling for different modes at the same time, in case several profiling functions are given as arguments of profile.Start(...), only last given profiling mode is triggered.