### PR TITLE
add ineffassign as a travis CI test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ matrix:
       script:
         - go vet $(go list ./... | grep -v vendor)
         - diff -u <(echo -n) <(gofmt -d $(find . -name "*\.go" | grep -v '\.git/' | grep -v vendor))
+        - utils/scripts/ineffassign.sh
 
     - language: go
       sudo: true

--- a/server/jwt/bench_test.go
+++ b/server/jwt/bench_test.go
@@ -50,6 +50,7 @@ func getTokenBench(require *require.Assertions) string {
 	require.NoError(err)
 
 	iyoCl, err := stubs.NewStubIYOClient("testorg", key)
+	require.NoError(err)
 
 	token, err := iyoCl.CreateJWT("mynamespace", itsyouonline.Permission{
 		Read:   true,

--- a/utils/scripts/ineffassign.sh
+++ b/utils/scripts/ineffassign.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+go get -u github.com/gordonklaus/ineffassign
+
+ineffassign client server cmd


### PR DESCRIPTION
ineffassign is a comunity Golang tool
which allows us to detect assignments which we do not use

this is very important as results should always be consumed if declared,
if you really do not want them you need to do so explicitly using an underscore,
for example ignoring an error would be pretty bad

this tool does not promise to catch all cases where this is possible,
but none the less it should help us to spot the most common ones