### PR TITLE
support unix sockets for GRPC servers

### DIFF
--- a/client/datastor/grpc/client.go
+++ b/client/datastor/grpc/client.go
@@ -64,6 +64,7 @@ func NewClient(addr, namespace string, jwtTokenGetter datastor.JWTTokenGetter) (
 	// ensure that we have a valid connection
 	conn, err := grpc.Dial(addr,
 		grpc.WithInsecure(),
+		grpc.WithDialer(Dial),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(math.MaxInt32),
 			grpc.MaxCallSendMsgSize(math.MaxInt32),

--- a/client/datastor/grpc/utils.go
+++ b/client/datastor/grpc/utils.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2017-2018 GIG Technology NV and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grpc
+
+import (
+	"net"
+	"strings"
+	"time"
+)
+
+// Dial the underlying connection of a GRPC connection.
+// If the given addr contains '/' and/or no colon, a UNIX network is assumed and used,
+// otherwise a TCP network is assumed and used.
+func Dial(addr string, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout(parseNetworkProtocol(addr), addr, timeout)
+}
+
+func parseNetworkProtocol(addr string) string {
+	if i := strings.IndexAny(addr, "/:"); i == -1 || addr[i] == '/' {
+		return "unix"
+	}
+	return "tcp"
+}

--- a/client/datastor/grpc/utils_test.go
+++ b/client/datastor/grpc/utils_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2017-2018 GIG Technology NV and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNetworkProtocol(t *testing.T) {
+	testCases := []struct {
+		address, protocol string
+	}{
+		{"foo", "unix"},
+		{"foo/bar", "unix"},
+		{"/foo", "unix"},
+		{"/foo/bar", "unix"},
+		{"foo:8000", "tcp"},
+		{"foo.bar:8000", "tcp"},
+		{"a.b.c.d:8000", "tcp"},
+		{"foo.bar", "unix"},
+		{"127.0.0.1:3030", "tcp"},
+	}
+	for _, testCase := range testCases {
+		protocol := parseNetworkProtocol(testCase.address)
+		assert.Equal(t, testCase.protocol, protocol)
+	}
+}

--- a/cmd/flag_test.go
+++ b/cmd/flag_test.go
@@ -50,35 +50,53 @@ func TestStringsFlag(t *testing.T) {
 
 func TestListenAddressFlag(t *testing.T) {
 	tt := []struct {
-		input string
-		err   error
-		value string
+		input   string
+		err     error
+		value   string
+		network string
 	}{
 		{
 			// default value
 			"",
 			nil,
 			":8080",
+			"tcp",
 		},
 		{
 			"8080",
-			errors.New("address 8080: missing port in address"),
-			"",
+			nil,
+			"8080",
+			"unix",
 		},
 		{
 			":8080",
 			nil,
 			":8080",
+			"tcp",
 		},
 		{
 			"127.0.0.1:8080",
 			nil,
 			"127.0.0.1:8080",
+			"tcp",
 		},
 		{
 			"badhost:8080",
 			errors.New("host not valid"),
 			"",
+			"tcp",
+		},
+		{
+			"foo",
+			nil,
+			"foo",
+			"unix",
+		},
+		{
+			"/var/foo",
+			nil,
+			"/var/foo",
+			"unix",
 		},
 	}
 
@@ -95,8 +113,11 @@ func TestListenAddressFlag(t *testing.T) {
 				err = l.Set(tc.input)
 			}
 			if tc.err != nil {
+				require.NotNil(err)
 				require.Equal(tc.err.Error(), err.Error())
 			} else {
+				require.NoError(err)
+				require.Equal(tc.network, l.NetworkProtocol())
 				require.Equal(tc.value, l.String())
 			}
 		})

--- a/cmd/zstor/commands/daemon.go
+++ b/cmd/zstor/commands/daemon.go
@@ -47,8 +47,10 @@ var daemonCmd = &cobra.Command{
 func daemonFunc(*cobra.Command, []string) error {
 	cmd.LogVersion()
 
-	// create a TCP listener for our daemon (server)
-	listener, err := net.Listen("tcp", daemonCfg.ListenAddress.String())
+	// create a UNIX/TCP listener for our daemon (server)
+	listener, err := net.Listen(
+		daemonCfg.ListenAddress.NetworkProtocol(),
+		daemonCfg.ListenAddress.String())
 	if err != nil {
 		return err
 	}
@@ -73,7 +75,9 @@ func daemonFunc(*cobra.Command, []string) error {
 	}()
 
 	log.Infof("Daemon Server interface: grpc")
-	log.Infof("Daemon Server listening on %s", listener.Addr().String())
+	log.Infof("Daemon Server listening on %s (net protocol: %s)",
+		listener.Addr().String(),
+		daemonCfg.ListenAddress.NetworkProtocol())
 
 	// wait until the daemon has to be gracefully closed,
 	// or until a fatal error occurs

--- a/cmd/zstordb/commands/root.go
+++ b/cmd/zstordb/commands/root.go
@@ -134,8 +134,10 @@ func rootFunc(*cobra.Command, []string) error {
 		}
 	}
 
-	// create a TCP listener for our server
-	listener, err := net.Listen("tcp", rootCfg.ListenAddress.String())
+	// create a UNIX/TCP listener for our server
+	listener, err := net.Listen(
+		rootCfg.ListenAddress.NetworkProtocol(),
+		rootCfg.ListenAddress.String())
 	if err != nil {
 		return err
 	}
@@ -151,7 +153,9 @@ func rootFunc(*cobra.Command, []string) error {
 	}()
 
 	log.Infof("Server interface: grpc")
-	log.Infof("Server listening on %s", listener.Addr().String())
+	log.Infof("Server listening on %s (net protocol: %s)",
+		listener.Addr().String(),
+		rootCfg.ListenAddress.NetworkProtocol())
 
 	select {
 	case err := <-errChan:


### PR DESCRIPTION
closes #460

This PR also makes it possible to bind a zstordb server to a unix socket, however, much more useful (and needed) is that it also allows for a daemon server to be bound to a unix socket.

As we do not have a daemon client yet, I cannot do the client-side of a daemon, but at least the daemon server can now be bound to a unix socket.

The algorithm is simple. If the string contains a `/`, we assume that it is a unix socket, as TCP addresses cannot have a `/` as part of the host or port. If a string contains a colon we however assume it's a TCP addr. If a string contains a `/` and `:` it would depend on which char is first, which is bad, but for now we don't care as we assume that no user would ever require that. In theory it should still result in a Unix path, but I don't see a reason why anyone would put a colon in their socket name, so for now I'm ok with this.

Thus to bind a daemon to `/var/zstordb/daemon` you would do: `-L /var/zstordb/daemon`, in order to bind to a local socket `daemon` in the current dir, you could do: `-L daemon`. Binding the daemon to a TCP addr is still possible by doing `-L :12345`.

As the zstordb (server and client) can now also be done over unix sockets (I guess only useful for dev purposes), the following example config would be legal:

```yaml
namespace: thedisk
datastor:
  shards:
    - /var/zstordb/server1
    - /foo/bar
    - foo.bar:12345
  pipeline:
    block_size: 4096
    compression:
      mode: default
    encryption:
      private_key: ab345678901234567890123456789012
    distribution:
      data_shards: 2
      parity_shards: 1
metastor:
  db:
    endpoints:
      - 127.0.0.1:2379
  encryption:
    private_key: ab345678901234567890123456789012
```