### PR TITLE
Added namespace flag to zstor

### DIFF
--- a/cmd/zstor/commands/file.go
+++ b/cmd/zstor/commands/file.go
@@ -31,9 +31,23 @@ import (
 var fileCmd = &cobra.Command{
 	Use:   "file",
 	Short: "Upload or download files to/from (a) 0-stor server(s).",
+	// overwrite the namespace config property, if it is given as a flag by the user
+	PersistentPreRunE: func(_cmd *cobra.Command, _args []string) error {
+		// Override namespace settings
+		if fileCfg.Namespace != "" {
+			config, err := getClientConfig()
+			if err != nil {
+				return err
+			}
+			log.Infof("overwrote namespace config property to '%s' (was: '%s')",
+				fileCfg.Namespace, config.Namespace)
+			config.Namespace = fileCfg.Namespace
+		}
+		return nil
+	},
 }
 
-// Used to hold file config flag values
+// Used to hold common file config flags
 var fileCfg struct {
 	Namespace string
 }
@@ -229,6 +243,9 @@ func init() {
 		fileRepairCmd,
 	)
 
+	fileCmd.PersistentFlags().StringVar(
+		&fileCfg.Namespace, "namespace", "", "Overrides Namespace (client) config property.")
+
 	fileUploadCmd.Flags().StringVarP(
 		&fileUploadCfg.Key, "key", "k", "",
 		"Key to use to store the file, required when uploading from STDIN, if empty use the name of the file as the key")
@@ -243,6 +260,4 @@ func init() {
 	fileMetadataCmd.Flags().BoolVar(
 		&fileMetadataCfg.JSONPrettyFormat, "json-pretty", false,
 		"Print the metadata in prettified JSON format instead of a custom human readable format.")
-	fileCmd.PersistentFlags().StringVarP(
-		&fileCfg.Namespace, "namespace", "n", "", "Overrides Namespace config option.")
 }

--- a/cmd/zstor/commands/file.go
+++ b/cmd/zstor/commands/file.go
@@ -33,6 +33,11 @@ var fileCmd = &cobra.Command{
 	Short: "Upload or download files to/from (a) 0-stor server(s).",
 }
 
+// Used to hold file config flag values
+var fileCfg struct {
+	Namespace string
+}
+
 // fileUploadCmd represents the file-upload command
 var fileUploadCmd = &cobra.Command{
 	Use:   "upload [path]",
@@ -238,4 +243,6 @@ func init() {
 	fileMetadataCmd.Flags().BoolVar(
 		&fileMetadataCfg.JSONPrettyFormat, "json-pretty", false,
 		"Print the metadata in prettified JSON format instead of a custom human readable format.")
+	fileCmd.PersistentFlags().StringVarP(
+		&fileCfg.Namespace, "namespace", "n", "", "Overrides Namespace config option.")
 }

--- a/cmd/zstor/commands/namespace.go
+++ b/cmd/zstor/commands/namespace.go
@@ -33,11 +33,47 @@ var namespaceCmd = &cobra.Command{
 	Short: "Manage namespaces and their permissions.",
 }
 
+var namespaceCmdCfg struct {
+	namespace string
+}
+
+func preRunNamespaceCommands(requiredArgs int) func(*cobra.Command, []string) error {
+	return func(_cmd *cobra.Command, args []string) error {
+		n := len(args)
+		if n < requiredArgs {
+			return fmt.Errorf("required at least %d arg(s), received %d", requiredArgs, n)
+		}
+		maxArgs := requiredArgs + 1
+		if n > maxArgs {
+			return fmt.Errorf("accepting maximum %d arg(s), received %d", maxArgs, n)
+		}
+
+		if n == maxArgs {
+			namespace := args[requiredArgs]
+
+			config, err := getClientConfig()
+			if err != nil {
+				return err
+			}
+			log.Infof("overwrote namespace config property to '%s' (was: '%s')",
+				namespace, config.Namespace)
+			// Override namespace settings
+			config.Namespace = namespace
+		}
+
+		return nil
+	}
+}
+
 // namespaceCreateCmd represents the namespace-create command
 var namespaceCreateCmd = &cobra.Command{
-	Use:   "create <name>",
+	Use:   "create [namespace]",
 	Short: "Create a namespace.",
-	Args:  cobra.ExactArgs(1),
+	Long: `Create namespace in IYO within an organization for a given name.
+
+If no namespace is given as positional argument, it is assumed that the namespace
+as defined in the (client) config file, is to be used.`,
+	PreRunE: preRunNamespaceCommands(0),
 	RunE: func(_cmd *cobra.Command, args []string) error {
 		iyoCl, err := getNamespaceManager()
 		if err != nil {
@@ -58,9 +94,13 @@ var namespaceCreateCmd = &cobra.Command{
 
 // namespaceDeleteCmd represents the namespace-delete command
 var namespaceDeleteCmd = &cobra.Command{
-	Use:   "delete <name>",
+	Use:   "delete [namespace]",
 	Short: "Delete a namespace.",
-	Args:  cobra.ExactArgs(1),
+	Long: `Delete namespace in IYO existing within an organization under a given name.
+
+If no namespace is given as positional argument, it is assumed that the namespace
+as defined in the (client) config file, is to be used.`,
+	PreRunE: preRunNamespaceCommands(0),
 	RunE: func(_cmd *cobra.Command, args []string) error {
 		iyoCl, err := getNamespaceManager()
 		if err != nil {
@@ -87,10 +127,13 @@ var namespacePermissionCmd = &cobra.Command{
 
 // namespaceSetPermissionCmd represents the namespace-permission-set command
 var namespaceSetPermissionCmd = &cobra.Command{
-	Use:   "set <userID> <namespace>",
+	Use:   "set <userID> [namespace]",
 	Short: "Set permissions.",
-	Long:  "Set permissions for a given user and namespace.",
-	Args:  cobra.ExactArgs(2),
+	Long: `Set permissions for a given user and namespace.
+
+If no namespace is given as positional argument, it is assumed that the namespace
+as defined in the (client) config file, is to be used.`,
+	PreRunE: preRunNamespaceCommands(1),
 	RunE: func(_cmd *cobra.Command, args []string) error {
 		iyoCl, err := getNamespaceManager()
 		if err != nil {
@@ -145,10 +188,13 @@ var namespaceGetPermissionCfg struct {
 
 // namespaceGetPermissionCmd represents the namespace-permission-get command
 var namespaceGetPermissionCmd = &cobra.Command{
-	Use:   "get <userID> <namespace>",
+	Use:   "get <userID> [namespace]",
 	Short: "Get permissions.",
-	Long:  "Get permissions for a given user and namespace.",
-	Args:  cobra.ExactArgs(2),
+	Long: `Get permissions for a given user and namespace.
+
+If no namespace is given as positional argument, it is assumed that the namespace
+as defined in the (client) config file, is to be used.`,
+	PreRunE: preRunNamespaceCommands(1),
 	RunE: func(_cmd *cobra.Command, args []string) error {
 		iyoCl, err := getNamespaceManager()
 		if err != nil {

--- a/cmd/zstor/commands/root.go
+++ b/cmd/zstor/commands/root.go
@@ -60,22 +60,39 @@ var rootCfg struct {
 	JobCount   int
 }
 
+// getConfigFile Reads path configuration file and rewrites the Namespace
+// value if the user provided another one with the Flag --namespace
+func getConfigFile(path string) (*client.Config, error) {
+	cfg, err := client.ReadConfig(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Override namespace settings
+	if fileCfg.Namespace != "" {
+		cfg.Namespace = fileCfg.Namespace
+		log.Infof("Setting namespace config to [%s]", fileCfg.Namespace)
+	}
+
+	return cfg, nil
+}
+
 func getClient() (*client.Client, error) {
-	cfg, err := client.ReadConfig(rootCfg.ConfigFile)
+	cfg, err := getConfigFile(rootCfg.ConfigFile)
 	if err != nil {
 		return nil, err
 	}
 	// create client
 	cl, err := client.NewClientFromConfigWithoutCaching(*cfg, rootCfg.JobCount)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create 0-stor client: %v", err)
+		return nil, fmt.Errorf("failed to create 0-stor client: (%v)", err)
 	}
 
 	return cl, nil
 }
 
 func getMetaClient() (*metastor.Client, error) {
-	clientCfg, err := client.ReadConfig(rootCfg.ConfigFile)
+	clientCfg, err := getConfigFile(rootCfg.ConfigFile)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +142,7 @@ func getMetaClient() (*metastor.Client, error) {
 }
 
 func getNamespaceManager() (*itsyouonline.Client, error) {
-	cfg, err := client.ReadConfig(rootCfg.ConfigFile)
+	cfg, err := getConfigFile(rootCfg.ConfigFile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
+ add namespace flag to file commands,
   which lets the user override the namespace property from the config, if defined;
+ make namespace positional argument optional in namespace commands,
   which will make the relevant namespace command use the namespace configured in the
   0-stor client config YAML file;

At any given point the user has to define the namespace at least in one location (command-line or config), and the command-line given namespace (label) will always have precedence over the one given in the YAML config file