### PR TITLE
async_splitter.Read : deletes sent buffer entry.

### DIFF
--- a/client/datastor/pipeline/async_splitter.go
+++ b/client/datastor/pipeline/async_splitter.go
@@ -491,6 +491,9 @@ func (asp *AsyncSplitterPipeline) Read(chunks []metatypes.Chunk, w io.Writer) er
 				}
 				expectedIndex++
 				data, ok = buffer[expectedIndex]
+				if ok {
+					delete(buffer, expectedIndex)
+				}
 			}
 		}
 


### PR DESCRIPTION
Deletes entry of buffer that already being sent to the Writer.

In current code, the buffer entry only getting deleted after the async splitter exited.

Part of OOM fix attempt reported at https://github.com/gigforks/minio/issues/30